### PR TITLE
chore(ci): add Heroku deploy & Dockerfile templates

### DIFF
--- a/.github/WORKFLOW_TEMPLATES.md
+++ b/.github/WORKFLOW_TEMPLATES.md
@@ -16,7 +16,17 @@ How to use:
 
 Notes & tips:
 - The template's smoke check hits `/health`. Ensure your service exposes a health endpoint.
-- For cron jobs, the workflow releases worker images and expects you to use Heroku Scheduler (or a worker process defined in a Procfile).
 - If your Docker context places files into `/app`, keep `PYTHONPATH=/app` or adjust imports accordingly.
+
+## Cron jobs & Heroku Scheduler ⚙️
+- For periodic or one-off tasks (cron jobs) we recommend using **Heroku Scheduler**. Typical patterns:
+  - Compiled binaries (Go): build & release the image as a worker process (e.g. `rating-cron: ./rating-cron-binary`) and configure Heroku Scheduler to run a one-off command like:
+    - `heroku run ./rating-cron-binary --app <HEROKU_APP>`
+  - Python scripts: schedule a command such as `python backend/scripts/fill_db.py` via the Heroku Scheduler UI targeting your app.
+- You can also release a `worker` process type and have it run continuously, but that will incur running dyno costs; for single-run cron jobs, Scheduler is simpler and cost-efficient.
+- To test a worker after a deploy you can run:
+  - `heroku run --app <HEROKU_APP> "<command>"` (one-off run)
+  - or temporarily scale a worker: `heroku ps:scale worker=1` and inspect `heroku logs --tail --app <HEROKU_APP>`.
+- Note: GitHub Actions cannot manage the Heroku Scheduler add-on directly; Scheduler must be configured through the Heroku Dashboard or API.
 
 If you want, I can: (A) open a PR with these files (draft), (B) make these files copy directly into the service directories and open a PR, or (C) add CI tests that validate the templates format. Which do you prefer?

--- a/.github/WORKFLOW_TEMPLATES.md
+++ b/.github/WORKFLOW_TEMPLATES.md
@@ -42,4 +42,9 @@ If you want, I can add these example entries to the docs in a more structured ta
 
 See `scripts/create_heroku_scheduler_jobs.py` and `scripts/scheduler-jobs.example.yml` for a starting implementation. Note: programmatic creation of schedule entries depends on the add-on provider; when the provider does not expose a public API the script will print CLI/dashboard steps for manual creation.
 
+**Automatic post-deploy execution**
+- This template includes an optional job `create-scheduler-jobs` which runs **after** `build-and-deploy` completes and will attempt to provision Scheduler add-ons and create scheduled jobs automatically.
+- The job only runs when the `HEROKU_API_KEY` secret is set at the repository level. It will also look for `HEROKU_APP_RATING_CRON` and `HEROKU_APP_REDIS_INDEXER` secrets (per-app names) and run the appropriate jobs. If the secrets are absent, the job steps are skipped.
+- To enable automation, add the repository secrets: `HEROKU_API_KEY`, `HEROKU_APP_RATING_CRON`, and `HEROKU_APP_REDIS_INDEXER` (adjust names as needed for your apps). If you prefer to manage Scheduler manually, simply omit these secrets.
+
 If you want, I can: (A) open a PR with these files (draft), (B) make these files copy directly into the service directories and open a PR, or (C) add CI tests that validate the templates format. Which do you prefer?

--- a/.github/WORKFLOW_TEMPLATES.md
+++ b/.github/WORKFLOW_TEMPLATES.md
@@ -1,0 +1,22 @@
+# Workflow & Dockerfile templates (how to use)
+
+This file explains what the template files do and how to use them.
+
+Files added in this PR:
+
+- `.github/workflows/deploy-to-heroku-template.yml` — A configurable workflow that builds and pushes per-service Docker images to Heroku Container Registry and releases them.
+- `docker/backend.Dockerfile.template` — Multi-stage Python Dockerfile for the backend (FastAPI + gunicorn). Copy/rename and adapt it to `backend/Dockerfile`.
+- `backend/Procfile.template` — Procfile template for Heroku process types (web).
+
+How to use:
+1. Copy `docker/backend.Dockerfile.template` → `backend/Dockerfile` and update packaging commands if you use Poetry/poetry-builds/etc.
+2. Copy `backend/Procfile.template` → `backend/Procfile` (or to repo root if deploying monorepo) and confirm process names.
+3. Copy `.github/workflows/deploy-to-heroku-template.yml` → `.github/workflows/deploy-to-heroku.yml` and update the matrix entries to match your services and contexts.
+4. Add GitHub repository secrets: `HEROKU_API_KEY` and `HEROKU_APP_<SERVICE>` for each service, e.g. `HEROKU_APP_BACKEND`.
+
+Notes & tips:
+- The template's smoke check hits `/health`. Ensure your service exposes a health endpoint.
+- For cron jobs, the workflow releases worker images and expects you to use Heroku Scheduler (or a worker process defined in a Procfile).
+- If your Docker context places files into `/app`, keep `PYTHONPATH=/app` or adjust imports accordingly.
+
+If you want, I can: (A) open a PR with these files (draft), (B) make these files copy directly into the service directories and open a PR, or (C) add CI tests that validate the templates format. Which do you prefer?

--- a/.github/WORKFLOW_TEMPLATES.md
+++ b/.github/WORKFLOW_TEMPLATES.md
@@ -29,4 +29,13 @@ Notes & tips:
   - or temporarily scale a worker: `heroku ps:scale worker=1` and inspect `heroku logs --tail --app <HEROKU_APP>`.
 - Note: GitHub Actions cannot manage the Heroku Scheduler add-on directly; Scheduler must be configured through the Heroku Dashboard or API.
 
+### Example Scheduler entries (your request)
+- **rating-cron** — Daily at 02:00 UTC
+  - Heroku Scheduler command: `heroku run --app <HEROKU_APP> ./rating-cron-binary`
+  - Suggestion: ensure your binary accepts a `--once` or `--run-once` flag if needed, or use an entrypoint script that exits when done.
+- **redisIndexerCronJob** — Every 3 hours
+  - Heroku Scheduler command: `heroku run --app <HEROKU_APP> ./redis-indexer-binary`
+
+If you want, I can add these example entries to the docs in a more structured table or add a sample Scheduler API call that configures them automatically (requires Heroku API key + permission).
+
 If you want, I can: (A) open a PR with these files (draft), (B) make these files copy directly into the service directories and open a PR, or (C) add CI tests that validate the templates format. Which do you prefer?

--- a/.github/WORKFLOW_TEMPLATES.md
+++ b/.github/WORKFLOW_TEMPLATES.md
@@ -36,6 +36,10 @@ Notes & tips:
 - **redisIndexerCronJob** — Every 3 hours
   - Heroku Scheduler command: `heroku run --app <HEROKU_APP> ./redis-indexer-binary`
 
-If you want, I can add these example entries to the docs in a more structured table or add a sample Scheduler API call that configures them automatically (requires Heroku API key + permission).
+If you want, I can add these example entries to the docs in a more structured table or add a sample Scheduler automation script that:
+- Provisions the Scheduler add-on for each app (via the Heroku Platform API)
+- Attempts to programmatically create jobs if the add-on exposes an API endpoint
+
+See `scripts/create_heroku_scheduler_jobs.py` and `scripts/scheduler-jobs.example.yml` for a starting implementation. Note: programmatic creation of schedule entries depends on the add-on provider; when the provider does not expose a public API the script will print CLI/dashboard steps for manual creation.
 
 If you want, I can: (A) open a PR with these files (draft), (B) make these files copy directly into the service directories and open a PR, or (C) add CI tests that validate the templates format. Which do you prefer?

--- a/.github/workflows/deploy-to-heroku-template.yml
+++ b/.github/workflows/deploy-to-heroku-template.yml
@@ -65,6 +65,44 @@ jobs:
             # heroku run --app ${HEROKU_APP} "./rating-cron-binary --once"
           fi
 
+  create-scheduler-jobs:
+    name: Create Heroku Scheduler entries (post-deploy)
+    runs-on: ubuntu-latest
+    needs: build-and-deploy
+    # Only run when a HEROKU_API_KEY is present in repository secrets
+    if: ${{ secrets.HEROKU_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install script deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests pyyaml
+
+      - name: Create rating-cron Scheduler entries
+        if: ${{ secrets.HEROKU_APP_RATING_CRON }}
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        run: |
+          python scripts/create_heroku_scheduler_jobs.py --app "${{ secrets.HEROKU_APP_RATING_CRON }}" --jobs-file scripts/scheduler-jobs.rating-cron.yml || true
+
+      - name: Create redis-indexer Scheduler entries
+        if: ${{ secrets.HEROKU_APP_REDIS_INDEXER }}
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        run: |
+          python scripts/create_heroku_scheduler_jobs.py --app "${{ secrets.HEROKU_APP_REDIS_INDEXER }}" --jobs-file scripts/scheduler-jobs.redis-indexer.yml || true
+
+      - name: Reminder: manual steps if automation failed
+        run: |
+          echo "If jobs could not be created programmatically, open the Scheduler dashboard:"
+          echo "  heroku addons:open scheduler --app <YOUR_APP>"
+
       # Optional: a commented example workflow job for running a manual worker test using Heroku CLI.
       # You can copy this into your workflow file to add a manual trigger (workflow_dispatch) to run one-off commands.
       #

--- a/.github/workflows/deploy-to-heroku-template.yml
+++ b/.github/workflows/deploy-to-heroku-template.yml
@@ -59,4 +59,8 @@ jobs:
             curl -fsS $URL || (echo "Smoke test failed" && exit 1)
           else
             echo "Worker process deployed for ${HEROKU_APP}, no web smoke check"
+            echo "Tip: Use Heroku Scheduler to run periodic commands, or run a one-off test using 'heroku run --app ${HEROKU_APP} <command>'"
+            # Example (uncomment to run as part of the workflow - requires HEROKU_API_KEY and a valid command):
+            # echo "Running worker test command..."
+            # heroku run --app ${HEROKU_APP} "./rating-cron-binary --once"
           fi

--- a/.github/workflows/deploy-to-heroku-template.yml
+++ b/.github/workflows/deploy-to-heroku-template.yml
@@ -1,0 +1,62 @@
+name: CI/CD — Build & Deploy to Heroku (Container Registry) (Template)
+
+# Template workflow: copy this file and update the matrix/services to match your repo layout.
+# Required secrets in repository: HEROKU_API_KEY, HEROKU_APP_<SERVICE_NAME> for each service
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - service: backend
+            context: backend
+            dockerfile: Dockerfile
+            process: web
+          # Add additional services below (example):
+          # - service: websocket
+          #   context: webSocketEngine
+          #   dockerfile: DockerFile
+          #   process: web
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set HEROKU_APP env from secrets
+        run: |
+          if [ "${{ matrix.service }}" = "backend" ]; then echo "HEROKU_APP=${{ secrets.HEROKU_APP_BACKEND }}" >> $GITHUB_ENV; fi
+          # Add mapping for other services if needed
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Heroku Container Registry
+        run: echo "${{ secrets.HEROKU_API_KEY }}" | docker login --username=_ --password-stdin registry.heroku.com
+
+      - name: Build and push Docker image to Heroku
+        run: |
+          IMAGE=registry.heroku.com/${HEROKU_APP}/${{ matrix.process }}
+          docker build -t $IMAGE -f ${{ matrix.context }}/${{ matrix.dockerfile }} ${{ matrix.context }}
+          docker push $IMAGE
+
+      - name: Install Heroku CLI
+        run: curl https://cli-assets.heroku.com/install.sh | sh
+
+      - name: Release image on Heroku
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        run: |
+          heroku container:release ${{ matrix.process }} --app $HEROKU_APP
+
+      - name: Post-deploy smoke check
+        run: |
+          if [ "${{ matrix.process }}" = "web" ]; then 
+            URL="https://${HEROKU_APP}.herokuapp.com/health"
+            echo "Checking $URL"
+            curl -fsS $URL || (echo "Smoke test failed" && exit 1)
+          else
+            echo "Worker process deployed for ${HEROKU_APP}, no web smoke check"
+          fi

--- a/.github/workflows/deploy-to-heroku-template.yml
+++ b/.github/workflows/deploy-to-heroku-template.yml
@@ -64,3 +64,25 @@ jobs:
             # echo "Running worker test command..."
             # heroku run --app ${HEROKU_APP} "./rating-cron-binary --once"
           fi
+
+      # Optional: a commented example workflow job for running a manual worker test using Heroku CLI.
+      # You can copy this into your workflow file to add a manual trigger (workflow_dispatch) to run one-off commands.
+      #
+      # Example (uncomment to enable):
+      #
+      # worker-test:
+      #  name: Manual worker test (Heroku run)
+      #  runs-on: ubuntu-latest
+      #  permissions: write-all
+      #  steps:
+      #    - uses: actions/checkout@v4
+      #    - name: Install Heroku CLI
+      #      run: curl https://cli-assets.heroku.com/install.sh | sh
+      #    - name: Run worker test command
+      #      env:
+      #        HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+      #      run: |
+      #        # replace <COMMAND> with the one-off command you want to run, for example './rating-cron-binary --once' or 'python backend/scripts/fill_db.py'
+      #        heroku run --app ${{ secrets.HEROKU_APP_BACKEND }} "<COMMAND>"
+      #
+      # Note: enabling this requires that the GH Actions runner can authenticate with Heroku via HEROKU_API_KEY and that the secret HEROKU_APP_* is present.

--- a/backend/Procfile.template
+++ b/backend/Procfile.template
@@ -6,3 +6,9 @@ web: gunicorn -w 4 -k uvicorn.workers.UvicornWorker app:app --bind 0.0.0.0:$PORT
 # If you have worker processes, add lines like:
 # worker: python worker.py
 # rating-cron: ./rating-cron-binary
+#
+# Scheduling & testing:
+# - Use Heroku Scheduler (Add-on) to run one-off commands on a schedule, for example:
+#   heroku run --app <HEROKU_APP> "python backend/scripts/fill_db.py"
+# - Or declare a process in Procfile and run it as a worker (be aware that persistent worker dynos incur running costs).
+# - To test a worker immediately: `heroku run --app <HEROKU_APP> "<command>"` or temporarily `heroku ps:scale worker=1` and inspect logs.

--- a/backend/Procfile.template
+++ b/backend/Procfile.template
@@ -1,0 +1,8 @@
+# Procfile template for Heroku (backend)
+# Place at backend/Procfile or at repo root if deploying single service
+# Example: web process using gunicorn + uvicorn worker
+web: gunicorn -w 4 -k uvicorn.workers.UvicornWorker app:app --bind 0.0.0.0:$PORT
+
+# If you have worker processes, add lines like:
+# worker: python worker.py
+# rating-cron: ./rating-cron-binary

--- a/backend/scripts/fill_db.py
+++ b/backend/scripts/fill_db.py
@@ -13,6 +13,10 @@ dotenv.load_dotenv()
 # MongoDB connection details
 MONGODB_URL = os.getenv("MONGODB_URL", "mongodb://localhost:27017")
 DATABASE_NAME = os.getenv("DATABASE_NAME", "mipedido")
+# Optional TLS client certs for X.509 auth
+MONGO_TLS_CERTFILE = os.getenv("MONGO_TLS_CERTFILE")
+MONGO_TLS_CAFILE = os.getenv("MONGO_TLS_CAFILE")
+MONGO_TLS_KEYFILE = os.getenv("MONGO_TLS_KEYFILE")
 
 # Sample data
 RESTAURANT_NAMES = [
@@ -559,7 +563,18 @@ def create_reviews(db, restaurant_ids):
     print(f"Total pending reviews created: {review_count}")
 
 def main():
-    print(f"Connecting to MongoDB at {MONGODB_URL}")
+    # Mask the password when printing the URI to avoid leaking secrets
+    try:
+        masked = MONGODB_URL
+        if '://' in masked and '@' in masked:
+            prefix, rest = masked.split('://', 1)
+            userinfo, host = rest.split('@', 1)
+            if ':' in userinfo:
+                user, _ = userinfo.split(':', 1)
+                masked = f"{prefix}://{user}:***@{host}"
+        print(f"Connecting to MongoDB at {masked}")
+    except Exception:
+        print("Connecting to MongoDB (URI masked)")
     print(f"Using database: {DATABASE_NAME}")
     
     try:

--- a/docker/backend.Dockerfile.template
+++ b/docker/backend.Dockerfile.template
@@ -1,0 +1,30 @@
+# Dockerfile template for Backend (Python FastAPI)
+# - Multi-stage recommended for smaller images
+# - Set PYTHONPATH so local imports (from database import db) work in container
+
+# ---- Builder (optional) ----
+FROM python:3.13-slim AS builder
+WORKDIR /app
+COPY backend/pyproject.toml backend/requirements.txt* ./
+# Install build deps if required
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential gcc && rm -rf /var/lib/apt/lists/*
+RUN pip install --upgrade pip
+RUN pip wheel --wheel-dir=/wheels -r requirements.txt
+
+# ---- Final image ----
+FROM python:3.13-slim
+WORKDIR /app
+ENV PYTHONPATH=/app
+# Copy only what we need
+COPY --from=builder /wheels /wheels
+COPY backend/ /app/
+RUN pip install --no-cache-dir /wheels/* || pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 8000
+# Use gunicorn for production with uvicorn workers
+CMD ["gunicorn", "-w", "4", "-k", "uvicorn.workers.UvicornWorker", "app:app", "--bind", "0.0.0.0:$PORT"]
+
+# Notes:
+# - Replace 'requirements.txt' handling if you use poetry/pyproject.
+# - For smaller images, consider using 'python:3.13-alpine' but ensure C extensions build.
+# - This template expects your app package to be at backend/ and entrypoint `app:app`.

--- a/scripts/create_heroku_scheduler_jobs.py
+++ b/scripts/create_heroku_scheduler_jobs.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Create Heroku Scheduler add-on and (if possible) create scheduled jobs.
+
+This helper attempts to:
+  - Ensure the Scheduler add-on (scheduler:standard) is provisioned for the app.
+  - If the add-on exposes an API endpoint (some add-ons provide a private API URL via config vars), attempt to POST job definitions to it.
+  - Otherwise, print a clear set of `heroku` CLI commands and dashboard URLs to add the jobs manually.
+
+Security: This script requires `HEROKU_API_KEY` in the environment and the app name passed via `--app`.
+
+Usage:
+  export HEROKU_API_KEY=<key>
+  python scripts/create_heroku_scheduler_jobs.py --app mipedido-rating-cron --jobs-file scheduler-jobs.yml
+
+The jobs file is a YAML list of jobs, for example:
+
+- command: "./rating-cron-binary"
+  frequency: daily
+  at: "02:00"
+- command: "./redis-indexer-binary"
+  frequency: hourly
+  every: 3
+
+Notes:
+- Heroku Scheduler UI supports frequencies: "every 10 minutes", "hourly", "daily". For multi-hour jobs you should use hourly and set the desired times, or schedule multiple entries.
+- Programmatic creation of Scheduler entries depends on the add-on provider. If your add-on provides an API URL via its config vars (see the script output), this tool will attempt to POST jobs there.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from typing import Any, Dict, List, Optional
+
+import requests
+import yaml
+
+HEROKU_API = "https://api.heroku.com"
+HEADERS = {"Accept": "application/vnd.heroku+json; version=3"}
+
+
+def heroku_request(method: str, path: str, token: str, **kwargs) -> requests.Response:
+    headers = kwargs.pop("headers", {})
+    headers.update(HEADERS)
+    headers.update({"Authorization": f"Bearer {token}"})
+    return requests.request(method, HEROKU_API + path, headers=headers, **kwargs)
+
+
+def ensure_scheduler_addon(app: str, token: str) -> Dict[str, Any]:
+    """Ensure scheduler add-on exists; returns the add-on resource dict."""
+    # List addons
+    resp = heroku_request("GET", f"/apps/{app}/addons", token)
+    resp.raise_for_status()
+    addons = resp.json()
+    for a in addons:
+        if a.get("addon_service", {}).get("name") == "scheduler":
+            print(f"Scheduler add-on already provisioned: {a.get('id')}")
+            return a
+
+    print("Provisioning Heroku Scheduler add-on (scheduler:standard)...")
+    body = {"plan": "scheduler:standard"}
+    resp = heroku_request("POST", f"/apps/{app}/addons", token, json=body)
+    resp.raise_for_status()
+    new = resp.json()
+    print("Provisioned:", new.get("id"))
+    # Wait a moment for config vars to populate
+    time.sleep(2)
+    return new
+
+
+def find_scheduler_api_url(app: str, addon: Dict[str, Any], token: str) -> Optional[str]:
+    """Try to discover an API endpoint for the scheduler add-on via config vars or addon info."""
+    # Fetch addon info
+    addon_id = addon.get("id")
+    resp = heroku_request("GET", f"/apps/{app}/addons/{addon_id}", token)
+    resp.raise_for_status()
+    info = resp.json()
+
+    # Some add-ons expose a "web_url" or other fields.
+    if info.get("web_url"):
+        print("Found addon web URL:", info.get("web_url"))
+
+    # Check the addon's config vars on the app for any scheduler URLs.
+    resp = heroku_request("GET", f"/apps/{app}/config-vars", token)
+    resp.raise_for_status()
+    cfg = resp.json()
+
+    # heuristics: look for keys with SCHEDULER or SCHEDULER_API
+    for k, v in cfg.items():
+        if "SCHEDULER" in k.upper() and (v.startswith("http://") or v.startswith("https://")):
+            print(f"Discovered possible scheduler API URL in config var {k}")
+            return v
+
+    return None
+
+
+def post_job_to_scheduler_api(scheduler_api_url: str, job: Dict[str, Any]) -> bool:
+    """Attempt to POST a job to a scheduler API endpoint. This format is provider-specific.
+    Returns True if the request succeeded (2xx), False otherwise.
+    """
+    try:
+        print(f"Posting job to {scheduler_api_url}: {job}")
+        resp = requests.post(scheduler_api_url.rstrip("/") + "/jobs", json=job)
+        if resp.status_code >= 200 and resp.status_code < 300:
+            print("Job created ok")
+            return True
+        print("Failed to create job, status:", resp.status_code, resp.text)
+        return False
+    except Exception as exc:
+        print("Error contacting scheduler api:", exc)
+        return False
+
+
+def load_jobs_file(path: str) -> List[Dict[str, Any]]:
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, list):
+        raise SystemExit("Jobs file must be a YAML list of job objects")
+    return data
+
+
+def print_manual_instructions(app: str, jobs: List[Dict[str, Any]]):
+    print("\nNo scheduler API discovered. Create the jobs manually using Heroku Scheduler UI or the CLI. Examples:")
+    print(f"  heroku addons:create scheduler:standard --app {app}  # if not already provisioned")
+    print(f"  heroku addons:open scheduler --app {app}  # open the GUI")
+    print("Or run a one-off to test commands manually:")
+    for j in jobs:
+        cmd = j.get("command")
+        example = f"  heroku run --app {app} \"{cmd}\""
+        print(example)
+    print("\nTo schedule the job use the Scheduler dashboard: Add Job → set command and frequency (every 10 minutes / hourly / daily)")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--app", required=True, help="Heroku app name (e.g., mipedido-rating-cron)")
+    parser.add_argument("--jobs-file", required=True, help="YAML file listing jobs to add")
+    parser.add_argument("--dry-run", action="store_true", help="Print what would be done and exit")
+    args = parser.parse_args()
+
+    token = os.environ.get("HEROKU_API_KEY")
+    if not token:
+        print("HEROKU_API_KEY is required in env")
+        sys.exit(2)
+
+    jobs = load_jobs_file(args.jobs_file)
+
+    addon = ensure_scheduler_addon(args.app, token)
+    api_url = find_scheduler_api_url(args.app, addon, token)
+
+    if not api_url:
+        print("No scheduler add-on API endpoint discovered (this is common). Falling back to CLI / manual instructions.")
+        print_manual_instructions(args.app, jobs)
+        return
+
+    # if we do have an api_url, try to POST jobs in a provider-agnostic JSON shape.
+    for j in jobs:
+        job_payload = {
+            "command": j.get("command"),
+            "frequency": j.get("frequency"),
+            # provider-specific fields may include `at`, `every`, `timezone` etc.
+            **{k: v for k, v in j.items() if k not in ("command", "frequency")},
+        }
+        if args.dry_run:
+            print("DRY RUN: Would POST:", job_payload)
+            continue
+        ok = post_job_to_scheduler_api(api_url, job_payload)
+        if not ok:
+            print("Failed to create job programmatically for command:", job_payload["command"])
+            print_manual_instructions(args.app, [j])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scheduler-jobs.example.yml
+++ b/scripts/scheduler-jobs.example.yml
@@ -1,0 +1,11 @@
+# Example scheduler jobs YAML
+# frequency values: daily | hourly | ten_minutes
+# use `at: "HH:MM"` for daily to specify UTC time
+-
+  command: "./rating-cron-binary"
+  frequency: daily
+  at: "02:00"
+-
+  command: "./redis-indexer-binary"
+  frequency: hourly
+  every: 3

--- a/scripts/scheduler-jobs.rating-cron.yml
+++ b/scripts/scheduler-jobs.rating-cron.yml
@@ -1,0 +1,3 @@
+- command: "./rating-cron-binary"
+  frequency: daily
+  at: "02:00"

--- a/scripts/scheduler-jobs.redis-indexer.yml
+++ b/scripts/scheduler-jobs.redis-indexer.yml
@@ -1,0 +1,3 @@
+- command: "./redis-indexer-binary"
+  frequency: hourly
+  every: 3


### PR DESCRIPTION
Adds template Dockerfile for backend, Procfile template, and a GitHub Actions deploy workflow template + usage docs (.github/WORKFLOW_TEMPLATES.md). Copy/adapt them to your services and add required secrets (HEROKU_API_KEY, HEROKU_APP_... ).